### PR TITLE
Fix: Prevent crash in 01_data_io_demo.py when pyarrow is missing

### DIFF
--- a/demos/01_data_io_demo.py
+++ b/demos/01_data_io_demo.py
@@ -27,28 +27,34 @@ def demo_basic_loading():
     sample_data.to_csv('temp_data/sample.csv', index=False)
     sample_data.to_excel('temp_data/sample.xlsx', index=False)
     sample_data.to_json('temp_data/sample.json', orient='records')
-    sample_data.to_parquet('temp_data/sample.parquet', index=False)
-    
+
     # Load from CSV
     print("\n📁 Loading CSV file...")
     df_csv = load('temp_data/sample.csv')
     print(f"✓ Loaded {len(df_csv)} rows from CSV")
     print(df_csv.head())
-    
+
     # Load from Excel
     print("\n📊 Loading Excel file...")
     df_excel = load('temp_data/sample.xlsx')
     print(f"✓ Loaded {len(df_excel)} rows from Excel")
-    
+
     # Load from JSON
     print("\n📋 Loading JSON file...")
     df_json = load('temp_data/sample.json')
     print(f"✓ Loaded {len(df_json)} rows from JSON")
-    
-    # Load from Parquet
+
+    # Load from Parquet (Safely wrapped to prevent crashes)
     print("\n🗂️ Loading Parquet file...")
-    df_parquet = load('temp_data/sample.parquet')
-    print(f"✓ Loaded {len(df_parquet)} rows from Parquet")
+    try:
+        # We attempt to save AND load here so we catch the missing engine error
+        sample_data.to_parquet('temp_data/sample.parquet', index=False)
+        df_parquet = load('temp_data/sample.parquet')
+        print(f"✓ Loaded {len(df_parquet)} rows from Parquet")
+    except ImportError:
+        print("⚠️ Skipped Parquet demo: 'pyarrow' or 'fastparquet' not installed.")
+    except Exception as e:
+        print(f"⚠️ Skipped Parquet demo: {str(e)}")
 
 
 def demo_folder_loading():
@@ -56,21 +62,21 @@ def demo_folder_loading():
     print("\n" + "=" * 60)
     print("DEMO 2: Batch Loading from Folder")
     print("=" * 60)
-    
+
     # Create multiple CSV files
     os.makedirs('temp_data/batch', exist_ok=True)
-    
+
     for i in range(3):
         df = pd.DataFrame({
             'id': range(i*10, (i+1)*10),
             'value': range(100, 110)
         })
         df.to_csv(f'temp_data/batch/file_{i+1}.csv', index=False)
-    
+
     print("\n📂 Loading all CSV files from folder...")
     dfs = read_folder('temp_data/batch', file_type='csv')
     print(f"✓ Loaded {len(dfs)} files")
-    
+
     for i, df in enumerate(dfs, 1):
         print(f"  File {i}: {len(df)} rows")
 
@@ -80,34 +86,39 @@ def demo_save_operations():
     print("\n" + "=" * 60)
     print("DEMO 3: Saving Data")
     print("=" * 60)
-    
+
     # Create sample data
     df = pd.DataFrame({
         'x': range(1, 6),
         'y': [10, 20, 30, 40, 50]
     })
-    
+
     os.makedirs('temp_data/output', exist_ok=True)
-    
+
     # Save as CSV
     print("\n💾 Saving as CSV...")
     save(df, 'temp_data/output/result.csv')
     print("✓ Saved to result.csv")
-    
+
     # Save as Excel
     print("\n💾 Saving as Excel...")
     save(df, 'temp_data/output/result.xlsx')
     print("✓ Saved to result.xlsx")
-    
+
     # Save as JSON
     print("\n💾 Saving as JSON...")
     save(df, 'temp_data/output/result.json')
     print("✓ Saved to result.json")
-    
-    # Save as Parquet
+
+    # Save as Parquet (Safely wrapped to prevent crashes)
     print("\n💾 Saving as Parquet...")
-    save(df, 'temp_data/output/result.parquet')
-    print("✓ Saved to result.parquet")
+    try:
+        save(df, 'temp_data/output/result.parquet')
+        print("✓ Saved to result.parquet")
+    except ImportError:
+        print("⚠️ Skipped Parquet save: 'pyarrow' or 'fastparquet' not installed.")
+    except Exception as e:
+        print(f"⚠️ Skipped Parquet save: {str(e)}")
 
 
 def cleanup():
@@ -122,14 +133,14 @@ if __name__ == "__main__":
     print("\n" + "🚀" * 30)
     print("DATA I/O OPERATIONS DEMO".center(60))
     print("🚀" * 30 + "\n")
-    
+
     try:
         demo_basic_loading()
         demo_folder_loading()
         demo_save_operations()
     finally:
         cleanup()
-    
+
     print("\n" + "✅" * 30)
     print("ALL DEMOS COMPLETED".center(60))
     print("✅" * 30 + "\n")


### PR DESCRIPTION
The `01_data_io_demo.py` demo currently crashes with an `ImportError` if the user does not have `pyarrow` or `fastparquet` installed.

I have wrapped the Parquet save/load operations in `try-except` blocks. Now, instead of crashing the entire script, it gracefully warns the user and skips those specific steps, allowing the rest of the demo to complete successfully.